### PR TITLE
Use basic auth for GitHub authentication

### DIFF
--- a/lib/tp-release.js
+++ b/lib/tp-release.js
@@ -65,11 +65,9 @@ module.exports = async function({ skipTag = false }) {
       await request({
         method: 'POST',
         uri: apiUrl,
-        qs: {
-          'access_token': githubAccessToken
-        },
         headers: {
-          'User-Agent': 'tom-jumbo-grumbo (@bendemboski)'
+          'User-Agent': 'tom-jumbo-grumbo (@bendemboski)',
+          'Authorization': `token ${githubAccessToken}`
         },
         body: {
           'tag_name': tagName,


### PR DESCRIPTION
They have deprecated putting the access token in the query param, and want us to use basic auth now