### PR TITLE
Allow releasing from `main` branch

### DIFF
--- a/lib/get-changelog.js
+++ b/lib/get-changelog.js
@@ -7,7 +7,7 @@ function getChangelog(fromRef, toRef) {
     throw new Error('No toRef specified');
   }
 
-  execSync("git fetch origin master --tags", {
+  execSync("git pull --tags", {
     stdio: [ 'pipe', 'ignore', 'pipe' ]
   });
 

--- a/lib/tp-release.js
+++ b/lib/tp-release.js
@@ -11,8 +11,8 @@ const colors = require('colors/safe');
 module.exports = async function({ skipTag = false }) {
   if (!process.env.RELEASE_ANY_BRANCH) {
     let branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
-    if (branch !== 'master') {
-      die('You must be on master to release');
+    if (![ 'master', 'main' ].includes(branch)) {
+      die('You must be on master or main to release');
     }
   }
 
@@ -106,7 +106,7 @@ function getLastVersionTag() {
 //
 async function buildReleaseNotes() {
   function build(fromRef) {
-    let changelog = getChangelog(fromRef, 'master');
+    let changelog = getChangelog(fromRef, 'HEAD');
     let changeLines = changelog.map(({ pr, description }) => `- ${pr} ${description}`);
     return changeLines.join('\n');
   }


### PR DESCRIPTION
Remove the hard-coded assumption that the default branch is `master` and simultaneously make the RELEASE_ANY_BRANCH environment variable actually work by comparing HEAD to the last tag, instead of comparing a hard-coded branch name (`master`) to the last tag.